### PR TITLE
Remove deprecated Xamarin skill from portfolio

### DIFF
--- a/src/components/SkillsView.tsx
+++ b/src/components/SkillsView.tsx
@@ -58,7 +58,6 @@ export const SkillsView = () => {
           <span className="m-1 p-2 bg-red-200 rounded">React Native</span>
           <span className="m-1 p-2 bg-red-200 rounded">Expo</span>
           <span className="m-1 p-2 bg-red-200 rounded">Flutter</span>
-          <span className="m-1 p-2 bg-red-200 rounded">Xamarin</span>
           <span className="m-1 p-2 bg-red-200 rounded">Android</span>
           <span className="m-1 p-2 bg-red-200 rounded">iOS</span>
         </div>


### PR DESCRIPTION
Xamarin has been deprecated by Microsoft, so it's been removed from
the Mobile skills section.

https://claude.ai/code/session_01XCHEzMhonrSjTWK5DLNmPP